### PR TITLE
test: set up jest and enzyme

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   collectCoverageFrom: [
-    "src/**/!(index).{js,ts}",
-    "helpers/**/!(index).{js,ts}"
+    "src/**/!(index).{jsx?,tsx?}",
+    "helpers/**/!(index).{jsx?,tsx?}"
   ],
   coverageDirectory: "coverage",
   testMatch: [
@@ -9,13 +9,22 @@ module.exports = {
     "<rootDir>/helpers/**/?(*.)(spec|test).(js|ts)?(x)",
   ],
   reporters: process.env.CI ? undefined : ["jest-spec-reporter"],
+  setupTestFrameworkScriptFile: "",
   rootDir: ".",
   moduleFileExtensions: [
     "ts",
+    "tsx",
     "js",
+    "jsx"
   ],
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
   testEnvironment: "node",
+  globals: {
+    "ts-jest": {
+      skipBabel: true
+    }
+  },
+  setupTestFrameworkScriptFile: "<rootDir>/setupTests.js"
 };

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,5 @@
+const { configure } = require("enzyme");
+const Adapter = require("enzyme-adapter-react-16");
+require("jsdom-global")();
+
+configure({ adapter: new Adapter() });


### PR DESCRIPTION
This does not include Jest snapshots. That feature will come at a later time

## Description

This is one of the final tests to setting up jest and enzyme

### Intent

<!--
  -- Please briefly explain how this work relates to the
  -- bigger goals of the project.
  -->
- update which files get tested
- fix incorrect sourcemaps

### Changes

<!--
  -- Please briefly enumerate the changes that you made.
  -- Note other improvements that may have been made as you
  -- were working.
  -->
- enable `skipBabel` in `ts-jest` to restore proper sourcemaps
- add `setupTestFrameworkScriptFile` where the `enzyme` setup lives.
- add `jsdom` and `jsdom-global` to project

### Notes

<!--
  -- Please briefly describe things to be aware of. Did you
  -- encounter anything unexpected while working, etc. This
  -- is also the place to help the reviewers understand and
  -- therefore be able to review your code more effectively
  -- and efficiently.
  -->

In order to properly use Enzyme's `mount` and `render` functions, the [docs](https://github.com/airbnb/enzyme/blob/master/docs/api/mount.md) indicate that it is also necessary to include `jsdom` into the configuration. `jsdom` will add the `document` object to test so that when `mount` and `render` are called, it mounts to a proper HTML DOM node.

## Checklist

Please go through the checklist below, marking off
completed ones. Leave the list intact for the reviewers'
use.

- [x] PR adheres to the [project's styleguide](./CONTRIBUTING.md)
- [x] PR name follows the [karma commit message convention](http://karma-runner.github.io/2.0/dev/git-commit-msg.html)
- [x] Adequate tests have been written
  - [x] the demo test is not present
  - [x] no useless tests
- [x] Latest code from `develop` has been merged into your branch
- [x] You have scrolled through and reviewed your changes, looking for small errors and inconsistencies
- [x] Absolutely no commented out code except for the JSDoc
- [x] Project with changes starts the server without error
  - [x] Component with changes has been tested
  - [x] UI has been hand-tested

## Disclosure

Thank you for submitting your PR!

Should your PR be merged in, two things will happen:

1. Your branch will be deleted in order to keep branches tidy
2. You will lose creative ownership over all code within the context of this project
    - Identical code in other projects are not of concern

#### Why #2?

Please refer to the [contributing guide](./CONTRIBUTING.md#preface)
