### PR TITLE
feat(button): add button component to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,12 @@
     "verify": "tsc"
   },
   "dependencies": {
+    "@material/button": "^0.35.0",
+    "classnames": "^2.2.5",
     "react": "^16.3.2"
   },
   "devDependencies": {
+    "@types/classnames": "^2.2.3",
     "@types/enzyme": "^3.1.10",
     "@types/jest": "^22.2.3",
     "@types/jsdom": "^11.0.4",

--- a/src/button/Button.spec.tsx
+++ b/src/button/Button.spec.tsx
@@ -33,7 +33,6 @@ describe("<Button />", () => {
 
       wrapper.find("button").simulate("click");
 
-
       expect(mockOnClick).toBeCalled();
       expect(mockOnClick).toHaveBeenCalledTimes(once);
       expect(spy).toHaveBeenCalledTimes(once);

--- a/src/button/Button.spec.tsx
+++ b/src/button/Button.spec.tsx
@@ -5,6 +5,8 @@ import Button from "./Button";
 
 
 const mockOnClick = jest.fn();
+const one = 1;
+const once = 1;
 
 describe("<Button />", () => {
   it("mounts properly", () => {
@@ -16,7 +18,6 @@ describe("<Button />", () => {
   describe("#render", () => {
     it("is called only once", () => {
       const spy = jest.spyOn(Button.prototype, "render");
-      const once = 1;
 
       const wrapper = mount(<Button />);
 
@@ -29,8 +30,6 @@ describe("<Button />", () => {
     it("simulates a click event", () => {
       const spy = jest.spyOn(Button.prototype, "render");
       const wrapper = shallow(<Button onClick={mockOnClick} />);
-      const once = 1;
-      const twice = 2;
 
       wrapper.find("button").simulate("click");
 
@@ -44,7 +43,6 @@ describe("<Button />", () => {
 
   it("contains a button element", () => {
     const wrapper = shallow(<Button />);
-    const one = 1;
 
     expect(wrapper.find("button")).toHaveLength(one);
     expect(wrapper.is("button")).toBe(true);

--- a/src/button/Button.spec.tsx
+++ b/src/button/Button.spec.tsx
@@ -1,0 +1,72 @@
+import { mount, shallow } from "enzyme";
+import * as React from "react";
+
+import Button from "./Button";
+
+
+const mockOnClick = jest.fn();
+
+describe("<Button />", () => {
+  it("mounts properly", () => {
+    const wrapper = shallow(<Button />);
+
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  describe("#render", () => {
+    it("is called only once", () => {
+      const spy = jest.spyOn(Button.prototype, "render");
+      const once = 1;
+
+      const wrapper = mount(<Button />);
+
+      expect(spy).toHaveBeenCalledTimes(once);
+      spy.mockClear();
+    });
+  });
+
+  describe("#onClick", () => {
+    it("simulates a click event", () => {
+      const spy = jest.spyOn(Button.prototype, "render");
+      const wrapper = shallow(<Button onClick={mockOnClick} />);
+      const once = 1;
+      const twice = 2;
+
+      wrapper.find("button").simulate("click");
+
+
+      expect(mockOnClick).toBeCalled();
+      expect(mockOnClick).toHaveBeenCalledTimes(once);
+      expect(spy).toHaveBeenCalledTimes(once);
+      spy.mockClear();
+    });
+  });
+
+  it("contains a button element", () => {
+    const wrapper = shallow(<Button />);
+    const one = 1;
+
+    expect(wrapper.find("button")).toHaveLength(one);
+    expect(wrapper.is("button")).toBe(true);
+  });
+
+  it("has a base className of `mdc-button`", () => {
+    const wrapper = shallow(<Button />);
+
+    expect(wrapper.find("button").hasClass("mdc-button")).toBe(true);
+  });
+
+  it("accepts and renders children", () => {
+    const wrapper = mount(<Button />);
+    const str = "button text";
+    const el = <div>{str}</div>;
+
+    expect(wrapper.prop("children")).toBe(undefined);
+
+    wrapper.setProps({ children: str });
+    expect(wrapper.text()).toBe(str);
+
+    wrapper.setProps({ children: el });
+    expect(wrapper.containsMatchingElement(el)).toBe(true);
+  });
+});

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import * as cn from "classnames";
+
+/**
+ * @name mdc-button
+ */
+
+export interface MDCButtonProps {
+  children?: string | React.ReactElement<any> | React.ReactNode;
+  onClick?: ((event: React.SyntheticEvent<HTMLButtonElement>) => void) | undefined;
+}
+
+export default class extends React.PureComponent<MDCButtonProps> {
+  render(): React.ReactElement<HTMLButtonElement> {
+    return (
+      <button className={cn("mdc-button")} onClick={this.props.onClick}>
+        { this.props.children }
+      </button>
+    );
+  }
+}

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -1,0 +1,1 @@
+export * from "./Button";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./button/index";

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
     "semicolon": [
       true,
       "always"
-    ]
+    ],
+    "no-magic-numbers": true
   },
   "linterOptions": {
     "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,9 +32,61 @@
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
 
+"@material/animation@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.34.0.tgz#a99cc9dabf7d0179b4da9a0aaa1575c4d1513823"
+
+"@material/base@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-0.35.0.tgz#8640c2da385e8cc393ff56153c5a319f5a7704cb"
+
+"@material/button@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/button/-/button-0.35.0.tgz#2c1df47ac71a9dd16998925557ef91d80c01b42c"
+  dependencies:
+    "@material/elevation" "^0.35.0"
+    "@material/ripple" "^0.35.0"
+    "@material/rtl" "^0.35.0"
+    "@material/theme" "^0.35.0"
+    "@material/typography" "^0.35.0"
+
+"@material/elevation@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-0.35.0.tgz#a0b8bbe346ebb29a4decd35b961aaf2635ff89bd"
+  dependencies:
+    "@material/animation" "^0.34.0"
+    "@material/theme" "^0.4.0"
+
+"@material/ripple@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.35.0.tgz#3670e04e02dd6efc1ff0546e5129b4e96ec55f70"
+  dependencies:
+    "@material/base" "^0.35.0"
+    "@material/theme" "^0.35.0"
+
+"@material/rtl@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.35.0.tgz#caae659e35a9bf1b9d91c734c8a3315a81bcde21"
+
+"@material/theme@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.35.0.tgz#a2c76f60b82a53d399b769ef91ec52e83ad3c3bd"
+
+"@material/theme@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.4.0.tgz#0aef1a0279b65c15990584fb8b8eca095c734641"
+
+"@material/typography@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-0.35.0.tgz#23ad7eb7c9789e69c7c3fa54df8fc311cd7fc4b1"
+
 "@types/cheerio@*":
   version "0.22.7"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.7.tgz#4a92eafedfb2b9f4437d3a4410006d81114c66ce"
+
+"@types/classnames@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.3.tgz#3f0ff6873da793870e20a260cada55982f38a9e5"
 
 "@types/enzyme@^3.1.10":
   version "3.1.10"
@@ -827,6 +879,10 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
 cli-boxes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

Using `material-components-web`, include the `mdc-button` component and create a React wrapper around it. Just a simple implementation. The button component is incomplete in terms of props and additional styles. It currently supports just the foundational `mdc-button`.

### Intent

<!--
  -- Please briefly explain how this work relates to the
  -- bigger goals of the project.
  -->
- Use the `classnames` library to add the ability for dynamic classnames (future feature, not yet implemented).
- Include starting set of tests using the Jest and Enzyme frameworks
- Create Button component
- Add `no-magic-numbers` rule to `tslint`
- 

### Changes

<!--
  -- Please briefly enumerate the changes that you made.
  -- Note other improvements that may have been made as you
  -- were working.
  -->
- the barrel
- src/Button/*
- package.json

### Notes

<!--
  -- Please briefly describe things to be aware of. Did you
  -- encounter anything unexpected while working, etc. This
  -- is also the place to help the reviewers understand and
  -- therefore be able to review your code more effectively
  -- and efficiently.
  -->
I learned a great deal about Jest, Enzyme, and JSDOM. This trio has proven to be extremely powerful in testing React components. Some things to briefly enumerate:

- if you create a spy in one test, clear that test before the test block exits
  - failure to do so may result in the spy being called more than once, causing future `calledOnce` tests to fail
- use `Enzyme.shallow` to get a high-level view of the DOM
- use `Enzyme.mount` to test the component lifecycle methods
- use `Enzyme.render` to get a static HTML tree. This will allow you to pass contexts through components
  - `render` is like a middle-ground between `shallow` and `mount`
  - I haven't quite found a good use case for this yet, but I'm sure it's nice...
- in the event a project should compile to JS, you cannot simply `import React from "react";`.
  - this is a reference to `react.d.ts`, not the actual library
  - use `import * as React from "react";` instead
  - these are called `synthetic imports`. TypeScript knows how to deal with these. commonjs and es-modules do not.

## Checklist

Please go through the checklist below, marking off
completed ones. Leave the list intact for the reviewers'
use.

- [x] PR adheres to the [project's styleguide](./CONTRIBUTING.md)
- [x] PR name follows the [karma commit message convention](http://karma-runner.github.io/2.0/dev/git-commit-msg.html)
- [x] Adequate tests have been written
  - [x] the demo test is not present
  - [x] no useless tests
- [x] Latest code from `develop` has been merged into your branch
- [x] You have scrolled through and reviewed your changes, looking for small errors and inconsistencies
- [x] Absolutely no commented out code except for the JSDoc
- [x] Project with changes starts the server without error
  - [x] Component with changes has been tested
  - [x] UI has been hand-tested

## Disclosure

Thank you for submitting your PR!

Should your PR be merged in, two things will happen:

1. Your branch will be deleted in order to keep branches tidy
2. You will lose creative ownership over all code within the context of this project
    - Identical code in other projects are not of concern

#### Why #2?

Please refer to the [contributing guide](./CONTRIBUTING.md#preface)
